### PR TITLE
Changed SPI Mode to 1 (was Mode 0)

### DIFF
--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -2,8 +2,8 @@
   This is a library for the Adafruit Thermocouple Sensor w/MAX31856
 
   Designed specifically to work with the Adafruit Thermocouple Sensor
-  ----> https://www.adafruit.com/products/xxxx
-
+  ----> https://www.adafruit.com/product/3263
+  
   These sensors use SPI to communicate, 4 pins are required to  
   interface
   Adafruit invests time and resources providing this open source code, 
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <SPI.h>
 
-static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE0);
+static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE1);
 
 
 // Software (bitbang) SPI


### PR DESCRIPTION
Timing charts in the datasheet show that timing should be mode 1, not 0.  I haven't tested this on Arduino, but forum members have, see this post: https://forums.adafruit.com/viewtopic.php?f=19&t=104926&p=535630&hilit=max31856

Please consider including my Python Library on the product learn page, so those with RasPi can use your board too: https://github.com/johnrbnsn/Adafruit_Python_MAX31856 
That library took some time to create, so I'd like others to benefit from it, too.