### PR TITLE
Poll instead of waiting, and asynchronous conversion.

### DIFF
--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -100,10 +100,11 @@ class Adafruit_MAX31856 {
   max31856_thermocoupletype_t getThermocoupleType(void);
 
   uint8_t readFault(void);
-  void oneShotTemperature(void);
+  bool oneShotTemperature(bool waitUntilDone=true);
 
-  float readCJTemperature(void);
-  float readThermocoupleTemperature(void);
+  bool isConversionDone(void);
+  float readCJTemperature(bool performOneShot=true);
+  float readThermocoupleTemperature(bool performOneShot=true);
 
   void setTempFaultThreshholds(float flow, float fhigh);
   void setColdJunctionFaultThreshholds(int8_t low, int8_t high);


### PR DESCRIPTION
This doesn't fix #12 but it's kinda related.

I modified the code to add two features.

1. Instead of waiting 250ms for a conversion to finish, we periodically poll the status register to see if the conversion finalized. This may shave a few ms off the conversion time.
2. The call to readCJTemperature/readThermocoupleTemperature can optionally start and wait for a conversion, or just read the register. I use C++ default parameters to keep backwards compatibility with old sketches. 

In this mode of operation it works great with "multitasking" stuff like an ESP8266 based webserver where waiting 250ms for a conversion kills HTTP performance. 

For this mode you have to start a conversion yourself with oneShotTemperature(false), do something else while it works, and when isConversionDone() returns true, call readCJTemperature(false) or readThermocoupleTemperature(false).