### PR TITLE
adding start and finish non-blocking get temp methods, adding helper method

### DIFF
--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -105,12 +105,19 @@ class Adafruit_MAX31856 {
   float readCJTemperature(void);
   float readThermocoupleTemperature(void);
 
+  void readThermocoupleTemperatureNonBlockingStart(void);
+  float readThermocoupleTemperatureNonBlockingFinish(void);
+  float readLastThermocoupleTemperatureNonBlocking(void);
+
   void setTempFaultThreshholds(float flow, float fhigh);
   void setColdJunctionFaultThreshholds(int8_t low, int8_t high);
   void setNoiseFilter(max31856_noise_filter_t noiseFilter);
 
  private:
   int8_t _sclk, _miso, _mosi, _cs;
+
+  unsigned long _lastTemperatureStartReadingTime;
+  float _lastTemperatureRead;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 


### PR DESCRIPTION
Added: 
  void readThermocoupleTemperatureNonBlockingStart(void);
  float readThermocoupleTemperatureNonBlockingFinish(void);
  float readLastThermocoupleTemperatureNonBlocking(void);

This enables users of the library to read the temperature in a non-blocking way (without delay() calls). The user can start the reading with readThermocoupleTemperatureNonBlockingStart() and, if called after 200ms, finish the reading with readThermocoupleTemperatureNonBlockingFinish() and get the temperature. If the user calls finish too soon, the last succesfully read temperature is returned.

There is a helper function readLastThermocoupleTemperatureNonBlocking() that gets the last read temperature and starts a new reading.

Please review and suggest changes.
Thank you,
Roberto