### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -9,7 +9,7 @@
  * Arduino platform.  It is designed specifically to work with the
  * Adafruit MAX31856 breakout: https://www.adafruit.com/products/3263
  *
- * These sensors use SPI to communicate, 4 pins are required to  
+ * These sensors use SPI to communicate, 4 pins are required to
  *  interface with the breakout.
  *
  * Adafruit invests time and resources providing this open source code,
@@ -42,7 +42,7 @@
 #include <stdlib.h>
 #include <SPI.h>
 
-static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE1);
+//static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE1);
 
 
 /**************************************************************************/
@@ -55,10 +55,15 @@ static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE
 */
 /**************************************************************************/
 Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi, int8_t spi_miso, int8_t spi_clk) {
+  spi_dev = Adafruit_SPIDevice(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000);
+
+  initialized = false;
+  /*
   _sclk = spi_clk;
   _cs = spi_cs;
   _miso = spi_miso;
   _mosi = spi_mosi;
+  */
 
 }
 
@@ -69,8 +74,13 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi, int8_t spi_
 */
 /**************************************************************************/
 Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs) {
+  spi_dev = Adafruit_SPIDevice(spi_cs, 1000000);
+
+  initialized = false;
+  /*
   _cs = spi_cs;
   _sclk = _miso = _mosi = -1;
+  */
 }
 
 /**************************************************************************/
@@ -80,22 +90,28 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs) {
 */
 /**************************************************************************/
 boolean Adafruit_MAX31856::begin(void) {
+  initialized = spi_dev.begin();
+
+  if (!initialized) return false;
+
+  /*
   pinMode(_cs, OUTPUT);
   digitalWrite(_cs, HIGH);
 
   if (_sclk != -1) {
     //define pin modes
-    pinMode(_sclk, OUTPUT); 
-    pinMode(_mosi, OUTPUT); 
+    pinMode(_sclk, OUTPUT);
+    pinMode(_mosi, OUTPUT);
     pinMode(_miso, INPUT);
   } else {
     //start and configure hardware SPI
     SPI.begin();
   }
+  */
 
   // assert on any fault
   writeRegister8(MAX31856_MASK_REG, 0x0);
-  
+
   writeRegister8(MAX31856_CR0_REG, MAX31856_CR0_OCFAULT0);
   setThermocoupleType(MAX31856_TCTYPE_K);
 
@@ -140,7 +156,7 @@ uint8_t Adafruit_MAX31856::readFault(void) {
 
 /**************************************************************************/
 /*!
-    @brief  Sets the threshhold for internal chip temperature range 
+    @brief  Sets the threshhold for internal chip temperature range
     for fault detection. NOT the thermocouple temperature range!
     @param  low Low (min) temperature, signed 8 bit so -128 to 127 degrees C
     @param  high High (max) temperature, signed 8 bit so -128 to 127 degrees C
@@ -153,7 +169,7 @@ void Adafruit_MAX31856::setColdJunctionFaultThreshholds(int8_t low, int8_t high)
 
 /**************************************************************************/
 /*!
-    @brief  Sets the mains noise filter. Can be set to 50 or 60hz. 
+    @brief  Sets the mains noise filter. Can be set to 50 or 60hz.
     Defaults to 60hz. You need to call this if you live in a 50hz country.
     @param  noiseFilter One of MAX31856_NOISE_FILTER_50HZ or MAX31856_NOISE_FILTER_60HZ
 */
@@ -170,7 +186,7 @@ void Adafruit_MAX31856::setNoiseFilter(max31856_noise_filter_t noiseFilter) {
 
 /**************************************************************************/
 /*!
-    @brief  Sets the threshhold for thermocouple temperature range 
+    @brief  Sets the threshhold for thermocouple temperature range
     for fault detection. NOT the internal chip temperature range!
     @param  flow Low (min) temperature, floating point
     @param  fhigh High (max) temperature, floating point
@@ -265,7 +281,7 @@ uint16_t Adafruit_MAX31856::readRegister16(uint8_t addr) {
   uint16_t ret = buffer[0];
   ret <<= 8;
   ret |=  buffer[1];
-  
+
   return ret;
 }
 
@@ -278,7 +294,7 @@ uint32_t Adafruit_MAX31856::readRegister24(uint8_t addr) {
   ret |=  buffer[1];
   ret <<= 8;
   ret |=  buffer[2];
-  
+
   return ret;
 }
 
@@ -286,9 +302,16 @@ uint32_t Adafruit_MAX31856::readRegister24(uint8_t addr) {
 void Adafruit_MAX31856::readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n) {
   addr &= 0x7F; // make sure top bit is not set
 
+  spixfer(addr);
+
+  while (n--) {
+    buffer[0] = spixfer(0xFF);
+    buffer++;
+  }
+  /*
   if (_sclk == -1)
     SPI.beginTransaction(max31856_spisettings);
-  else 
+  else
     digitalWrite(_sclk, HIGH);
 
   digitalWrite(_cs, LOW);
@@ -307,15 +330,20 @@ void Adafruit_MAX31856::readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n)
     SPI.endTransaction();
 
   digitalWrite(_cs, HIGH);
+  */
 }
 
 
 void Adafruit_MAX31856::writeRegister8(uint8_t addr, uint8_t data) {
   addr |= 0x80; // make sure top bit is set
 
+  spixfer(addr);
+  spixfer(data);
+
+  /*
   if (_sclk == -1)
     SPI.beginTransaction(max31856_spisettings);
-  else 
+  else
     digitalWrite(_sclk, HIGH);
 
   digitalWrite(_cs, LOW);
@@ -329,11 +357,20 @@ void Adafruit_MAX31856::writeRegister8(uint8_t addr, uint8_t data) {
     SPI.endTransaction();
 
   digitalWrite(_cs, HIGH);
+  */
 }
 
 
 
 uint8_t Adafruit_MAX31856::spixfer(uint8_t x) {
+
+  //return spi_dev.transfer(x);
+
+  spi_dev.write(&x, 1);
+  spi_dev.read(&x, 1);
+  return x;
+
+  /*
   if (_sclk == -1)
     return SPI.transfer(x);
 
@@ -349,4 +386,5 @@ uint8_t Adafruit_MAX31856::spixfer(uint8_t x) {
       reply |= 1;
   }
   return reply;
+  */
 }

--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -42,8 +42,6 @@
 #include <stdlib.h>
 #include <SPI.h>
 
-//static SPISettings max31856_spisettings = SPISettings(500000, MSBFIRST, SPI_MODE1);
-
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -67,7 +67,7 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi, int8_t spi_
 */
 /**************************************************************************/
 Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs) {
-  spi_dev = Adafruit_SPIDevice(spi_cs, 1000000);
+  spi_dev = Adafruit_SPIDevice(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1);
 
   initialized = false;
 }

--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -5,7 +5,7 @@
  * Arduino platform.  It is designed specifically to work with the
  * Adafruit MAX31856 breakout: https://www.adafruit.com/products/3263
  *
- * These sensors use SPI to communicate, 4 pins are required to  
+ * These sensors use SPI to communicate, 4 pins are required to
  *  interface with the breakout.
  *
  * Adafruit invests time and resources providing this open source code,
@@ -38,10 +38,10 @@
 #define MAX31856_LTHFTL_REG        0x06    ///< Linearized Temperature High Fault Threshold Register, LSB
 #define MAX31856_LTLFTH_REG        0x07    ///< Linearized Temperature Low Fault Threshold Register, MSB
 #define MAX31856_LTLFTL_REG        0x08    ///< Linearized Temperature Low Fault Threshold Register, LSB
-#define MAX31856_CJTO_REG          0x09    ///< Cold-Junction Temperature Offset Register 
+#define MAX31856_CJTO_REG          0x09    ///< Cold-Junction Temperature Offset Register
 #define MAX31856_CJTH_REG          0x0A    ///< Cold-Junction Temperature Register, MSB
 #define MAX31856_CJTL_REG          0x0B    ///< Cold-Junction Temperature Register, LSB
-#define MAX31856_LTCBH_REG         0x0C    ///< Linearized TC Temperature, Byte 2 
+#define MAX31856_LTCBH_REG         0x0C    ///< Linearized TC Temperature, Byte 2
 #define MAX31856_LTCBM_REG         0x0D    ///< Linearized TC Temperature, Byte 1
 #define MAX31856_LTCBL_REG         0x0E    ///< Linearized TC Temperature, Byte 0
 #define MAX31856_SR_REG            0x0F    ///< Fault Status Register
@@ -83,8 +83,10 @@ typedef enum
  #include "WProgram.h"
 #endif
 
+#include <Adafruit_SPIDevice.h>
+
 /**************************************************************************/
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with MAX31856
 */
 /**************************************************************************/
@@ -110,7 +112,9 @@ class Adafruit_MAX31856 {
   void setNoiseFilter(max31856_noise_filter_t noiseFilter);
 
  private:
-  int8_t _sclk, _miso, _mosi, _cs;
+  Adafruit_SPIDevice spi_dev = NULL;
+  boolean initialized;
+  //int8_t _sclk, _miso, _mosi, _cs;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 

--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -114,7 +114,6 @@ class Adafruit_MAX31856 {
  private:
   Adafruit_SPIDevice spi_dev = NULL;
   boolean initialized;
-  //int8_t _sclk, _miso, _mosi, _cs;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 
@@ -123,7 +122,6 @@ class Adafruit_MAX31856 {
   uint32_t readRegister24(uint8_t addr);
 
   void     writeRegister8(uint8_t addr, uint8_t reg);
-  uint8_t spixfer(uint8_t addr);
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MAX31856 library
-version=1.0.3
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit Thermocouple Amplifier breakout with MAX31856
@@ -7,3 +7,4 @@ paragraph=Library for the Adafruit Thermocouple Amplifier breakout with MAX31856
 category=Sensors
 url=https://github.com/adafruit/Adafruit_MAX31856
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #19 converts to BusIO usage. Tested on UNO and Feather M0.

**note to future self** - the need to set SPI Mode 1 for HW SPI wasn't obvious, relates to MAX's auto detecting mode via SCLK state when CS is asserted.

**UNO HW SPI**
```
MAX31856 thermocouple test
Thermocouple type: K Type
Cold Junction Temp: 23.53
Thermocouple Temp: 22.48
Cold Junction Temp: 23.58
Thermocouple Temp: 26.08
Cold Junction Temp: 23.61
Thermocouple Temp: 27.79
Cold Junction Temp: 23.55
```

**UNO SW SPI**
```
MAX31856 thermocouple test
Thermocouple type: K Type
Cold Junction Temp: 23.61
Thermocouple Temp: 22.32
Cold Junction Temp: 23.55
Thermocouple Temp: 27.62
Cold Junction Temp: 23.55
Thermocouple Temp: 27.91
Cold Junction Temp: 23.58
```

**Feather M0 Express HW SPI**
```
MAX31856 thermocouple test
Thermocouple type: K Type
Cold Junction Temp: 23.73
Thermocouple Temp: 22.88
Cold Junction Temp: 23.75
Thermocouple Temp: 24.45
Cold Junction Temp: 23.78
Thermocouple Temp: 26.67
Cold Junction Temp: 23.81
```

**Feather M0 Express SW SPI**
```
MAX31856 thermocouple test
Thermocouple type: K Type
Cold Junction Temp: 23.73
Thermocouple Temp: 21.96
Cold Junction Temp: 23.69
Thermocouple Temp: 25.45
Cold Junction Temp: 23.70
Thermocouple Temp: 27.04
Cold Junction Temp: 23.70
```
