### PR TITLE
Update conversion modes

### DIFF
--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -57,8 +57,8 @@
 
 /** Noise filtering options enum. Use with setNoiseFilter() */
 typedef enum {
-MAX31856_NOISE_FILTER_50HZ,
-MAX31856_NOISE_FILTER_60HZ
+  MAX31856_NOISE_FILTER_50HZ,
+  MAX31856_NOISE_FILTER_60HZ
 } max31856_noise_filter_t;
 
 /** Multiple types of thermocouples supported */
@@ -75,6 +75,13 @@ typedef enum
   MAX31856_VMODE_G8  = 0b1000,
   MAX31856_VMODE_G32 = 0b1100,
 } max31856_thermocoupletype_t;
+
+/** Temperature conversion mode */
+typedef enum {
+  MAX31856_ONESHOT,
+  MAX31856_ONESHOT_NOWAIT,
+  MAX31856_CONTINUOUS
+} max31856_conversion_mode_t;
 
 
 #if (ARDUINO >= 100)
@@ -98,11 +105,16 @@ class Adafruit_MAX31856 {
 
   boolean begin(void);
 
+  void setConversionMode(max31856_conversion_mode_t mode);
+  max31856_conversion_mode_t getConversionMode(void);
+
   void setThermocoupleType(max31856_thermocoupletype_t type);
   max31856_thermocoupletype_t getThermocoupleType(void);
 
   uint8_t readFault(void);
-  void oneShotTemperature(void);
+
+  void triggerOneShot(void);
+  bool conversionComplete(void);
 
   float readCJTemperature(void);
   float readThermocoupleTemperature(void);
@@ -114,6 +126,8 @@ class Adafruit_MAX31856 {
  private:
   Adafruit_SPIDevice spi_dev = NULL;
   boolean initialized;
+
+  max31856_conversion_mode_t conversionMode;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 

--- a/examples/max31856_continuous/max31856_continuous.ino
+++ b/examples/max31856_continuous/max31856_continuous.ino
@@ -1,0 +1,55 @@
+// This example demonstrates continuous conversion mode using the
+// DRDY pin to check for conversion completion.
+
+#include <Adafruit_MAX31856.h>
+
+#define DRDY_PIN 5
+
+// Use software SPI: CS, DI, DO, CLK
+//Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, 11, 12, 13);
+// use hardware SPI, just pass in the CS pin
+Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10);
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+  Serial.println("MAX31856 thermocouple test");
+
+  pinMode(DRDY_PIN, INPUT);
+
+  if (!maxthermo.begin()) {
+    Serial.println("Could not initialize thermocouple.");
+    while (1) delay(10);
+  }
+
+  maxthermo.setThermocoupleType(MAX31856_TCTYPE_K);
+
+  Serial.print("Thermocouple type: ");
+  switch (maxthermo.getThermocoupleType() ) {
+    case MAX31856_TCTYPE_B: Serial.println("B Type"); break;
+    case MAX31856_TCTYPE_E: Serial.println("E Type"); break;
+    case MAX31856_TCTYPE_J: Serial.println("J Type"); break;
+    case MAX31856_TCTYPE_K: Serial.println("K Type"); break;
+    case MAX31856_TCTYPE_N: Serial.println("N Type"); break;
+    case MAX31856_TCTYPE_R: Serial.println("R Type"); break;
+    case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
+    case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
+    case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x8 Gain mode"); break;
+    default: Serial.println("Unknown"); break;
+  }
+
+  maxthermo.setConversionMode(MAX31856_CONTINUOUS);
+}
+
+void loop() {
+  // The DRDY output goes low when a new conversion result is available
+  int count = 0;
+  while (digitalRead(DRDY_PIN)) {
+    if (count++ > 200) {
+      count = 0;
+      Serial.print(".");
+    }
+  }
+  Serial.println(maxthermo.readThermocoupleTemperature());
+}

--- a/examples/max31856_manual/max31856_manual.ino
+++ b/examples/max31856_manual/max31856_manual.ino
@@ -1,0 +1,61 @@
+// This example demonstrates doing a one-shot measurement "manually".
+// Separate calls are made to trigger the conversion and then check
+// for conversion complete. While this typically only takes a couple
+// 100 milliseconds, that times is made available by separating these
+// two steps.
+
+#include <Adafruit_MAX31856.h>
+
+// Use software SPI: CS, DI, DO, CLK
+//Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, 11, 12, 13);
+// use hardware SPI, just pass in the CS pin
+Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10);
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+  Serial.println("MAX31856 thermocouple test");
+
+  if (!maxthermo.begin()) {
+    Serial.println("Could not initialize thermocouple.");
+    while (1) delay(10);
+  }
+
+  maxthermo.setThermocoupleType(MAX31856_TCTYPE_K);
+
+  Serial.print("Thermocouple type: ");
+  switch (maxthermo.getThermocoupleType() ) {
+    case MAX31856_TCTYPE_B: Serial.println("B Type"); break;
+    case MAX31856_TCTYPE_E: Serial.println("E Type"); break;
+    case MAX31856_TCTYPE_J: Serial.println("J Type"); break;
+    case MAX31856_TCTYPE_K: Serial.println("K Type"); break;
+    case MAX31856_TCTYPE_N: Serial.println("N Type"); break;
+    case MAX31856_TCTYPE_R: Serial.println("R Type"); break;
+    case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
+    case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
+    case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x8 Gain mode"); break;
+    default: Serial.println("Unknown"); break;
+  }
+
+  maxthermo.setConversionMode(MAX31856_ONESHOT_NOWAIT);
+}
+
+void loop() {
+  // trigger a conversion, returns immediately
+  maxthermo.triggerOneShot();
+
+  //
+  // here's where you can do other things
+  //
+  delay(500); // replace this with whatever
+  //
+  //
+
+  // check for conversion complete and read temperature
+  if (maxthermo.conversionComplete()) {
+    Serial.println(maxthermo.readThermocoupleTemperature());
+  } else {
+    Serial.println("Conversion not complete!");
+  }
+}

--- a/examples/max31856_oneshot/max31856_oneshot.ino
+++ b/examples/max31856_oneshot/max31856_oneshot.ino
@@ -1,3 +1,6 @@
+// Basic example using one-shot measurement.
+// The call to readThermocoupleTemperature() is blocking for O(100ms)
+
 #include <Adafruit_MAX31856.h>
 
 // Use software SPI: CS, DI, DO, CLK
@@ -7,6 +10,7 @@ Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, 11, 12, 13);
 
 void setup() {
   Serial.begin(115200);
+  while (!Serial) delay(10);
   Serial.println("MAX31856 thermocouple test");
 
   maxthermo.begin();
@@ -28,14 +32,13 @@ void setup() {
     default: Serial.println("Unknown"); break;
   }
 
-
 }
 
 void loop() {
-  Serial.print("Cold Junction Temp: "); 
+  Serial.print("Cold Junction Temp: ");
   Serial.println(maxthermo.readCJTemperature());
 
-  Serial.print("Thermocouple Temp: "); 
+  Serial.print("Thermocouple Temp: ");
   Serial.println(maxthermo.readThermocoupleTemperature());
   // Check and print any faults
   uint8_t fault = maxthermo.readFault();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MAX31856 library
-version=1.1.0
+version=1.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit Thermocouple Amplifier breakout with MAX31856


### PR DESCRIPTION
This is for issue #12 and is similar to PR's #14 and #16.

Adds support for three general modes of operation:

1. **One-Shot** - This is a simple blocking (~100ms) call to convert and read the TC temperature. This should cover the majority of use cases. This is an update of the previous read function and changes the 250ms fixed delay to a polling loop.
2. **Continuous** - The MAX31856 is always on and always converting. Use of the DRDY pin is needed to coordinate reads when new conversions are available.
3. **Manual** - (aka One-Shot No Wait) This is like One-Shot but does not block waiting for conversion. The user must take care of both triggering the start of a one-shot measurement and then checking for conversion complete. The only benefit to this approach is allowing use of the ~100ms conversion wait time.

Examples have been added to demonstrate each of the above modes.

**ONE-SHOT**
![Screenshot from 2020-05-21 09-10-23](https://user-images.githubusercontent.com/8755041/82580843-96e6a200-9b44-11ea-8d93-bf78073262f9.png)

**CONTINUOUS**
![Screenshot from 2020-05-21 09-09-13](https://user-images.githubusercontent.com/8755041/82580874-a108a080-9b44-11ea-88f0-3abb580effdb.png)

**MANUAL** (ONE-SHOT NOWAIT)
![Screenshot from 2020-05-21 09-11-05](https://user-images.githubusercontent.com/8755041/82580945-b251ad00-9b44-11ea-8754-eed6cb92ef28.png)

