### PR TITLE
Fix NULL pointer assign to object

### DIFF
--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -53,11 +53,8 @@
 */
 /**************************************************************************/
 Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi,
-                                     int8_t spi_miso, int8_t spi_clk) {
-  spi_dev = Adafruit_SPIDevice(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000);
-
-  initialized = false;
-}
+                                     int8_t spi_miso, int8_t spi_clk)
+    : spi_dev(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000) {}
 
 /**************************************************************************/
 /*!
@@ -65,12 +62,8 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi,
     @param  spi_cs Any pin for SPI Chip Select
 */
 /**************************************************************************/
-Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs) {
-  spi_dev =
-      Adafruit_SPIDevice(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1);
-
-  initialized = false;
-}
+Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs)
+    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
 
 /**************************************************************************/
 /*!
@@ -80,7 +73,7 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs) {
    ID)
 */
 /**************************************************************************/
-boolean Adafruit_MAX31856::begin(void) {
+bool Adafruit_MAX31856::begin(void) {
   initialized = spi_dev.begin();
 
   if (!initialized)

--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -113,7 +113,7 @@ public:
                     int8_t spi_clk);
   Adafruit_MAX31856(int8_t spi_cs);
 
-  boolean begin(void);
+  bool begin(void);
 
   void setConversionMode(max31856_conversion_mode_t mode);
   max31856_conversion_mode_t getConversionMode(void);
@@ -134,8 +134,8 @@ public:
   void setNoiseFilter(max31856_noise_filter_t noiseFilter);
 
 private:
-  Adafruit_SPIDevice spi_dev = NULL;
-  boolean initialized;
+  Adafruit_SPIDevice spi_dev;
+  bool initialized = false;
 
   max31856_conversion_mode_t conversionMode;
 


### PR DESCRIPTION
Analogous to the fix in https://github.com/adafruit/Adafruit-MAX31855-library/pull/42.
Fixing the same warning as described in https://github.com/adafruit/Adafruit-MAX31855-library/issues/41.

Some notes why not using a pointer to the device and creating the device on the heap in https://github.com/adafruit/Adafruit-MAX31855-library/issues/41#issuecomment-700543918

Tested on an UNO with the examples.
