### PR TITLE
Added function readThermocoupleVoltage for VMODE_G8 and VMODE_G32 modes

### DIFF
--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -128,6 +128,7 @@ public:
 
   float readCJTemperature(void);
   float readThermocoupleTemperature(void);
+  float readThermocoupleVoltage(void);
 
   void setTempFaultThreshholds(float flow, float fhigh);
   void setColdJunctionFaultThreshholds(int8_t low, int8_t high);
@@ -138,6 +139,7 @@ private:
   bool initialized = false;
 
   max31856_conversion_mode_t conversionMode;
+  max31856_thermocoupletype_t ThermocoupleType;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 

--- a/examples/max31856_vmode/max31856_vmode/max31856_vmode.ino
+++ b/examples/max31856_vmode/max31856_vmode/max31856_vmode.ino
@@ -1,0 +1,63 @@
+// This example demonstrates doing a one-shot measurement "manually" in VMODE8 or VMODE32 mode. 
+// Separate calls are made to trigger the conversion and then check
+// for conversion complete. While this typically only takes a couple
+// 100 milliseconds, that times is made available by separating these
+// two steps.
+
+#include <Adafruit_MAX31856.h>
+
+// Use software SPI: CS, DI, DO, CLK
+//Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, 11, 12, 13);
+// use hardware SPI, just pass in the CS pin
+Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10);
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+  Serial.println("MAX31856 thermocouple test in Voltage Gain mode");
+
+  if (!maxthermo.begin()) {
+    Serial.println("Could not initialize thermocouple.");
+    while (1) delay(10);
+  }
+
+  maxthermo.setThermocoupleType(MAX31856_VMODE_G8); // or VMODE_G32, other modes will return NA values
+
+  Serial.print("Thermocouple type: ");
+  switch (maxthermo.getThermocoupleType() ) {
+    case MAX31856_TCTYPE_B: Serial.println("B Type"); break;
+    case MAX31856_TCTYPE_E: Serial.println("E Type"); break;
+    case MAX31856_TCTYPE_J: Serial.println("J Type"); break;
+    case MAX31856_TCTYPE_K: Serial.println("K Type"); break;
+    case MAX31856_TCTYPE_N: Serial.println("N Type"); break;
+    case MAX31856_TCTYPE_R: Serial.println("R Type"); break;
+    case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
+    case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
+    case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x32 Gain mode"); break;
+    default: Serial.println("Unknown"); break;
+  }
+
+  maxthermo.setConversionMode(MAX31856_ONESHOT_NOWAIT);
+}
+
+void loop() {
+  // trigger a conversion, returns immediately
+  maxthermo.triggerOneShot();
+
+  //
+  // here's where you can do other things
+  //
+  delay(500); // replace this with whatever
+  //
+  //
+
+  // check for conversion complete and read temperature
+  if (maxthermo.conversionComplete()) {
+    // Voltage is read in µV
+    // Any other mode than MAX31856_VMODE_G8 or MAX31856_VMODE_G32 will output NAN values with the readThermocoupleVoltage function
+    Serial.println(maxthermo.readThermocoupleVoltage());
+  } else {
+    Serial.println("Conversion not complete!");
+  }
+}


### PR DESCRIPTION
Hi, 
Changes made: 

- I added the new function readThermocoupleVoltage to read thermocouple voltage in µV in VMODE_G8 and VMODE_G32 modes in Adafruit_MAX31856.cpp 
- I added the new variable ThermocoupleType in Adafruit_MAX31856.h to check if the thermocouple is in voltage mode or not when calling the function. if not, the function return NAN
- I created a new example  max31856_vmode

Voltage is computed as described in the datasheet of the Max31856 (19 bit code is a function of Vin) and multiplied by 1000000 to output in µV. 

The code was tested in both modes with a type T thermocouple with temperatures between 0 and 100 °C and give similar results for a constant temperature. I did not test the function with other thermocouples or temperature ranges. 

Best regards,
