### PR TITLE
Set correct SPI mode for bit-banged SPI

### DIFF
--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -54,7 +54,8 @@
 /**************************************************************************/
 Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi,
                                      int8_t spi_miso, int8_t spi_clk)
-    : spi_dev(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000) {}
+    : spi_dev(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000,
+              SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
 
 /**************************************************************************/
 /*!


### PR DESCRIPTION
Sets the correct SPI mode when using bit-banged SPI. This mode is already set when using hardware SPI, but for whatever reason not if using bit-banged SPI.

This was required to get the example code running on an ESP32 device without using any hardware SPI.