### PR TITLE
Allow user to specify which SPI port to use.

### DIFF
--- a/Adafruit_MAX31856.cpp
+++ b/Adafruit_MAX31856.cpp
@@ -61,10 +61,11 @@ Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi,
 /*!
     @brief  Instantiate MAX31856 object and use hardware SPI
     @param  spi_cs Any pin for SPI Chip Select
+    @param _spi which spi buss to use.
 */
 /**************************************************************************/
-Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs)
-    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
+Adafruit_MAX31856::Adafruit_MAX31856(int8_t spi_cs, SPIClass *_spi)
+    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1, _spi) {}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31856.h
+++ b/Adafruit_MAX31856.h
@@ -111,7 +111,7 @@ class Adafruit_MAX31856 {
 public:
   Adafruit_MAX31856(int8_t spi_cs, int8_t spi_mosi, int8_t spi_miso,
                     int8_t spi_clk);
-  Adafruit_MAX31856(int8_t spi_cs);
+  Adafruit_MAX31856(int8_t spi_cs, SPIClass *_spi = &SPI);
 
   bool begin(void);
 

--- a/examples/max31856_manual/max31856_manual.ino
+++ b/examples/max31856_manual/max31856_manual.ino
@@ -10,6 +10,8 @@
 //Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, 11, 12, 13);
 // use hardware SPI, just pass in the CS pin
 Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10);
+// use hardware SPI, pass in the CS pin and using SPI1
+//Adafruit_MAX31856 maxthermo = Adafruit_MAX31856(10, &SPI1);
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
This follows the same changes I made for the MAX31855 library, for a different PJRC forum member.

So far I have tested that it builds.

Earlier today I suggested the changes to a different user  and they made the changes and it worked for them.

More details on the thread: https://forum.pjrc.com/threads/62418-second-spi-channel-teensy-4-1?p=275900&viewfull=1#post275900

It would be great if someone would make a pass through all of your libraries that are based on your spi_dev object and
would verify that users can use the alternate spi ports
