### PR TITLE
Fixed typo in examples

### DIFF
--- a/examples/max31856_continuous/max31856_continuous.ino
+++ b/examples/max31856_continuous/max31856_continuous.ino
@@ -35,7 +35,7 @@ void setup() {
     case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
     case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
     case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
-    case MAX31856_VMODE_G32: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x32 Gain mode"); break;
     default: Serial.println("Unknown"); break;
   }
 

--- a/examples/max31856_manual/max31856_manual.ino
+++ b/examples/max31856_manual/max31856_manual.ino
@@ -36,7 +36,7 @@ void setup() {
     case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
     case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
     case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
-    case MAX31856_VMODE_G32: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x32 Gain mode"); break;
     default: Serial.println("Unknown"); break;
   }
 

--- a/examples/max31856_oneshot/max31856_oneshot.ino
+++ b/examples/max31856_oneshot/max31856_oneshot.ino
@@ -28,7 +28,7 @@ void setup() {
     case MAX31856_TCTYPE_S: Serial.println("S Type"); break;
     case MAX31856_TCTYPE_T: Serial.println("T Type"); break;
     case MAX31856_VMODE_G8: Serial.println("Voltage x8 Gain mode"); break;
-    case MAX31856_VMODE_G32: Serial.println("Voltage x8 Gain mode"); break;
+    case MAX31856_VMODE_G32: Serial.println("Voltage x32 Gain mode"); break;
     default: Serial.println("Unknown"); break;
   }
 


### PR DESCRIPTION
Hi,

just fixed the serial output string for thermocouple type MAX31856_VMODE_G32 in the examples.